### PR TITLE
Remove Static Properties

### DIFF
--- a/src/dependencies/default-expiration.parser.ts
+++ b/src/dependencies/default-expiration.parser.ts
@@ -1,12 +1,15 @@
 import { DexxStringExpirationParser, DexxTimestampService } from '../dexx-types';
 import { DefaultTimestampService } from './default-timestamp.service';
 
-export class DefaultExpirationParser implements DexxStringExpirationParser {
-  public static readonly InvalidInput = 'invalid expiration submitted';
-  private timestampService: DexxTimestampService;
+import { dexxConfig, DexxConfig } from '../dexx-config';
 
-  constructor(timestampService?: DexxTimestampService) {
+export class DefaultExpirationParser implements DexxStringExpirationParser {
+  private timestampService: DexxTimestampService;
+  private config: DexxConfig;
+
+  constructor(timestampService?: DexxTimestampService, config?: DexxConfig) {
     this.timestampService = timestampService || new DefaultTimestampService();
+    this.config = config || dexxConfig;
   }
 
   public getExpirationTimestamp(expiration: string): number {
@@ -15,7 +18,7 @@ export class DefaultExpirationParser implements DexxStringExpirationParser {
 
     const regex = /^(\d+)([smhdwny])$/;
     if (!regex.test(expiration)) {
-      throw new Error(DefaultExpirationParser.InvalidInput);
+      throw new Error(this.config.ErrorMessages.InvalidExpirationInput);
     }
 
     const matches = regex.exec(expiration) || [];

--- a/src/dependencies/default-hash-provider.ts
+++ b/src/dependencies/default-hash-provider.ts
@@ -1,16 +1,18 @@
 import uuid5 = require('uuid/v5');
+import { dexxConfig, DexxConfig } from '../dexx-config';
 
 export type HashFunction = (input: string, salt: string) => string;
 
 export class DefaultHashProvider {
-  public static readonly HashNamepace = 'e33fc024-e9a4-473f-a15b-59dc83145b1c';
   private readonly hashFn: HashFunction;
+  private readonly config: DexxConfig;
 
-  constructor(hashFunc?: HashFunction) {
+  constructor(hashFunc?: HashFunction, config?: DexxConfig) {
     this.hashFn = hashFunc || uuid5;
+    this.config = config || dexxConfig;
   }
 
   public hash(input: string): string {
-    return this.hashFn(input, DefaultHashProvider.HashNamepace);
+    return this.hashFn(input, this.config.HashProviderNamespace);
   }
 }

--- a/src/dexx-config.ts
+++ b/src/dexx-config.ts
@@ -1,0 +1,39 @@
+import { CallInfo } from "./http/call-manager";
+
+export interface DexxErrorMessages {
+  InvalidExpirationInput: string;
+  HttpClientEmptyUrl: string;
+  HttpClientEmptyExpiration: string;
+  HttpClientFetchError: string;
+  CallManagerNoProcess: string;
+  FetchFunctionRequired: string;
+  FetchUrlUnknownError: string;
+}
+
+export interface DexxConfig {
+  HttpClientCacheKey: string;
+  CallManagerTimeout: number;
+  CallManagerPollingTime: number;
+  CallManagerDefaultInfo: CallInfo;
+  ErrorMessages: DexxErrorMessages
+  HashProviderNamespace: string;
+}
+
+export const dexxConfig: DexxConfig = {
+  HttpClientCacheKey: '__dexx_http_hash__',
+  CallManagerPollingTime: 50,
+  CallManagerTimeout: 1000,
+  CallManagerDefaultInfo: {
+    processId: '', complete: false, errorOccurred: false, data: null, validUntil: 0
+  },
+  HashProviderNamespace: 'e33fc024-e9a4-473f-a15b-59dc83145b1c',
+  ErrorMessages: {
+    InvalidExpirationInput: 'invalid expiration submitted',
+    HttpClientEmptyUrl: 'A valid url is required.',
+    HttpClientEmptyExpiration: 'A valid expiration is required.',
+    HttpClientFetchError: 'could not process returned response',
+    CallManagerNoProcess: 'No process was found with the given ID',
+    FetchFunctionRequired: 'No fetch function provided or found',
+    FetchUrlUnknownError: 'An unexpected error occurred making remote call'
+  }
+};

--- a/src/http/dexx-http.ts
+++ b/src/http/dexx-http.ts
@@ -3,27 +3,27 @@ import { DexxHttpHeaders, DexxHttpResponse } from './dexx-http-types';
 import { FetchUrlService } from './fetch-url.service';
 
 import { DefaultHashProvider } from '../dependencies/default-hash-provider';
+import { dexxConfig, DexxConfig } from '../dexx-config';
 import { DexxAttributeMap, DexxStorage } from '../dexx-types';
 import { IdxStorage } from '../idx/idx-storage';
 
 export class DexxHttp {
-  public static readonly CacheKey = '__dexx_http_hash__';
-  public static readonly EmptyUrlError = 'A valid url is required.';
-  public static readonly EmptyExpirationError = 'A valid expiration is required.';
-  public static readonly FetchError = 'could not process returned response';
   private dexxClient: DexxStorage;
   private callManager: CallManager;
   private hashProvider: DefaultHashProvider;
   private fetchUrl: FetchUrlService;
+  private config: DexxConfig;
 
   constructor(dexxClient?: DexxStorage,
               callManager?: CallManager,
               hashProvider?: DefaultHashProvider,
-              fetchUrl?: FetchUrlService) {
+              fetchUrl?: FetchUrlService,
+              config?: DexxConfig) {
     this.dexxClient = dexxClient || new IdxStorage();
     this.callManager = callManager || new CallManager();
     this.hashProvider = hashProvider || new DefaultHashProvider();
     this.fetchUrl = fetchUrl || new FetchUrlService();
+    this.config = config || dexxConfig;
   }
 
   public async get(url: string,
@@ -33,12 +33,12 @@ export class DexxHttp {
 
     url = url.trim();
     if (url.length < 1) {
-      throw new Error(DexxHttp.EmptyUrlError);
+      throw new Error(this.config.ErrorMessages.HttpClientEmptyUrl);
     }
 
     expiration = expiration.trim();
     if (expiration.length < 1) {
-      throw new Error(DexxHttp.EmptyExpirationError);
+      throw new Error(this.config.ErrorMessages.HttpClientEmptyExpiration);
     }
 
     attributes = attributes || {};
@@ -46,7 +46,7 @@ export class DexxHttp {
 
     const hash = this.hashProvider.hash(`${JSON.stringify(attributes)}${url}`);
     const storageAttributes: DexxAttributeMap = { ...attributes };
-    storageAttributes[`${DexxHttp.CacheKey}`] = [hash];
+    storageAttributes[`${this.config.HttpClientCacheKey}`] = [hash];
 
     try {
       const cachedData = await this.dexxClient.getFirst(storageAttributes, false);
@@ -69,8 +69,7 @@ export class DexxHttp {
     }
     catch(e) {
       this.callManager.endProcess(hash, null, true);
-      throw new Error(DexxHttp.FetchError);
+      throw new Error(this.config.ErrorMessages.HttpClientFetchError);
     }
   }
-
 }

--- a/src/idx/idx-config.ts
+++ b/src/idx/idx-config.ts
@@ -19,6 +19,8 @@ export interface IdxErrorMessages {
   RemoveAttributeError: string;
   RemoveDataError: string;
   DataItemNotFound: string;
+  SaveDataItemError: string;
+  SaveAttributeError: string;
 }
 
 export const idxConfig: IdxConfig = {
@@ -37,6 +39,8 @@ export const idxConfig: IdxConfig = {
     NoDataItemsFound:'No items matching the given attributes could be found',
     RemoveAttributeError: 'An error occurred attempting to remove the given data attributes',
     RemoveDataError: 'An error occurred trying to remove data matching the given attributes',
-    DataItemNotFound: 'No data item with the given ID could be found.'
+    DataItemNotFound: 'No data item with the given ID could be found.',
+    SaveDataItemError: 'an error occurred trying to write data to indexeddb',
+    SaveAttributeError: 'an error occurred trying to write attribute data to indexeddb'
   }
 };

--- a/src/idx/idx-save-data.ts
+++ b/src/idx/idx-save-data.ts
@@ -7,8 +7,6 @@ import { DefaultExpirationParser } from '../dependencies/default-expiration.pars
 import { DexxAttributeMap, DexxStringExpirationParser } from '../dexx-types';
 
 export class IdxSaveData {
-  public static readonly IdxWriteError = 'an error occurred trying to write data to indexeddb';
-  public static readonly IdxAttributeError = 'an error occurred trying to write attribute data to indexeddb';
   private openDb: OpenDbService;
   private expirationParser: DexxStringExpirationParser;
   private config: IdxConfig;
@@ -39,7 +37,7 @@ export class IdxSaveData {
         const request = itemStore.add(item);
 
         request.onerror = () => {
-          reject(IdxSaveData.IdxWriteError);
+          reject(this.config.ErrorMessages.SaveDataItemError);
         };
 
         request.onsuccess = (event) => {
@@ -60,7 +58,7 @@ export class IdxSaveData {
         const request = attrStore.add(attributeItem);
 
         request.onerror = () => {
-          reject(IdxSaveData.IdxAttributeError);
+          reject(this.config.ErrorMessages.SaveAttributeError);
         };
 
         request.onsuccess = () => {

--- a/test/http/call-manager.test.ts
+++ b/test/http/call-manager.test.ts
@@ -1,5 +1,6 @@
 import { CallInfo, CallManager, DexxTimestampService } from '../../src';
 import { InMemoryRepository } from '../../src/dependencies/in-memory-repository';
+import { dexxConfig } from '../../src/dexx-config';
 
 describe('CallManager', () => {
   let utcTimestampFn: jest.Mock;
@@ -54,7 +55,7 @@ describe('CallManager', () => {
 
     test('expect the in-memory repo to be called with given process ID', () => {
       const processId = 'process-id';
-      const expectedCallInfo = { ...CallManager.DefaultCallInfo, processId };
+      const expectedCallInfo = { ...dexxConfig.CallManagerDefaultInfo, processId };
       service().registerProcess(processId);
 
       expect(addDataFn).toHaveBeenCalledWith(processId, expectedCallInfo);
@@ -70,7 +71,7 @@ describe('CallManager', () => {
     });
 
     test('given valid data with no error expect repo updated correctly', () => {
-      const validUntil = CallManager.Timeout;
+      const validUntil = dexxConfig.CallManagerTimeout;
       const processId = 'process-id';
       const data = { prop1: 'does-not-matter' };
       service().endProcess(processId, data, false);
@@ -82,7 +83,7 @@ describe('CallManager', () => {
     });
 
     test('given an error expect repo updated correctly', () => {
-      const validUntil = CallManager.Timeout;
+      const validUntil = dexxConfig.CallManagerTimeout;
       const processId = 'process-id';
       service().endProcess(processId, null, true);
 
@@ -104,7 +105,7 @@ describe('CallManager', () => {
       service().followProcess('bad-process-id')
         .then(() => fail())
         .catch(e => {
-          expect(e.message).toBe(CallManager.NoProcessError);
+          expect(e.message).toBe(dexxConfig.ErrorMessages.CallManagerNoProcess);
           done();
         });
     });

--- a/test/http/dexx-http.test.ts
+++ b/test/http/dexx-http.test.ts
@@ -1,6 +1,7 @@
 import { CallManager, DexxAttributeMap, DexxHttp, DexxStorage } from '../../src';
 import { DefaultHashProvider } from '../../src/dependencies/default-hash-provider';
 import { FetchUrlService } from '../../src/http/fetch-url.service';
+import { dexxConfig } from '../../src/dexx-config';
 
 describe('DexxHttp', () => {
   const url = 'https://api.example.com/widgets/22';
@@ -36,7 +37,7 @@ describe('DexxHttp', () => {
           fail(); done();
         })
         .catch(e => {
-          expect(e.message).toBe(DexxHttp.EmptyUrlError);
+          expect(e.message).toBe(dexxConfig.ErrorMessages.HttpClientEmptyUrl);
           done();
         });
     });
@@ -47,7 +48,7 @@ describe('DexxHttp', () => {
           fail(); done();
         })
         .catch(e => {
-          expect(e.message).toBe(DexxHttp.EmptyExpirationError);
+          expect(e.message).toBe(dexxConfig.ErrorMessages.HttpClientEmptyExpiration);
           done();
         });
     });
@@ -58,7 +59,7 @@ describe('DexxHttp', () => {
     const hash = 'valid-hash';
     const storedObj = { key: 'value' };
     const props: DexxAttributeMap = {};
-    props[`${DexxHttp.CacheKey}`] = [hash];
+    props[`${dexxConfig.HttpClientCacheKey}`] = [hash];
 
     describe('if the data has been cached by the storage service', () => {
       let result: any = null;
@@ -168,7 +169,7 @@ describe('DexxHttp', () => {
           });
 
           test('expect the service to throw an error', () => {
-            expect(result.message).toBe(DexxHttp.FetchError);
+            expect(result.message).toBe(dexxConfig.ErrorMessages.HttpClientFetchError);
           });
 
           test('expect `endProcess` function called', () => {

--- a/test/http/fetch-url.service.test.ts
+++ b/test/http/fetch-url.service.test.ts
@@ -1,4 +1,5 @@
 import { FetchUrlService } from '../../src/http/fetch-url.service';
+import { dexxConfig } from '../../src/dexx-config';
 
 describe('FetchUrlService', () => {
   let fetchFn: jest.Mock;
@@ -8,7 +9,7 @@ describe('FetchUrlService', () => {
   test('if no fetch function is supplied, expect error', () => {
     window.fetch = false as any;
 
-    expect(() => { new FetchUrlService(); }).toThrowError(FetchUrlService.FetchFunctionRequired);
+    expect(() => { new FetchUrlService(); }).toThrowError(dexxConfig.ErrorMessages.FetchFunctionRequired);
   });
 
   describe('given an unexpected error from fetch function', () => {
@@ -27,7 +28,7 @@ describe('FetchUrlService', () => {
     });
 
     test('expect error rethrown with message', async () => {
-      expect(result.message).toBe(FetchUrlService.CallError);
+      expect(result.message).toBe(dexxConfig.ErrorMessages.FetchUrlUnknownError);
     });
 
     test('expect fetch function called with proper parameters', () => {


### PR DESCRIPTION
All public readonly properties have been removed from classes. These variables were being used as configuration variables so they have been moved to either the IdxConfig or DexxConfig files. This also solves the problem of creating ambient initialization in declaration files.